### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides web search capabilities to AI agents using the Bocha API.
 
+<a href="https://glama.ai/mcp/servers/@intounknown/mcp-bocha">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@intounknown/mcp-bocha/badge" alt="MCP-Bocha MCP server" />
+</a>
+
 ## Introduction
 
 MCP-Bocha is a tool that exposes Bocha AI's web search API capabilities through the Model Context Protocol. It allows AI assistants to search the web programmatically, enabling tasks such as information retrieval, research, and up-to-date data collection.


### PR DESCRIPTION
This PR adds a badge for the [MCP-Bocha](https://glama.ai/mcp/servers/@intounknown/mcp-bocha) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@intounknown/mcp-bocha">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@intounknown/mcp-bocha/badge" alt="MCP-Bocha MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.